### PR TITLE
Add .env file support as input type

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Heavily inspired by [CocoaPods-Keys](https://github.com/orta/cocoapods-keys) & [
 
 ## Features
 
-- 🔐 **Multiple Input Sources**: Environment variables, 1Password, Firebase Remote Config (experimental)
+- 🔐 **Multiple Input Sources**: Environment variables, `.env` files, 1Password, Firebase Remote Config (experimental)
 - 🎯 **Environment-based Configuration**: Different keys for development, staging, and production
 - 🔒 **Obfuscation**: XOR cipher with random salt generation
 - 🚀 **Swift Code Generation**: Type-safe access to your keys
@@ -96,6 +96,36 @@ input:
   type: env
   keyMapping:
     API_KEY: MY_CUSTOM_ENV_VAR  # Optional: map to different env var names
+```
+
+#### .env Files
+```yaml
+input:
+  type: dotenv
+  filePath: ./.env  # Optional: defaults to .env
+  keyMapping:
+    API_KEY: MY_CUSTOM_KEY  # Optional: map to different key names
+```
+
+**Features:**
+- Variable interpolation: `DATABASE_URL=${DB_HOST}:${DB_PORT}`
+- Multi-line values using heredoc syntax (`"""` or `'''`)
+- Comments (lines starting with `#`)
+- Quoted values (single or double quotes)
+
+**Example `.env` file:**
+```env
+# Database configuration
+DB_HOST=localhost
+DB_PORT=5432
+DB_CONNECTION=${DB_HOST}:${DB_PORT}
+
+# Multi-line private key
+PRIVATE_KEY="""
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAw...
+-----END RSA PRIVATE KEY-----
+"""
 ```
 
 #### 1Password

--- a/Sources/PouchFramework/Engine.swift
+++ b/Sources/PouchFramework/Engine.swift
@@ -51,6 +51,8 @@ public final class Engine {
             }
             self.onePasswordFetcher = fetcher
             return try await fetcher.fetch(declarations: declarations, section: section, keyMapping: keyMapping)
+        case let .dotenv(filePath, keyMapping):
+            return try await DotEnvFetcher(filePath: filePath).fetch(declarations: declarations, keyMapping: keyMapping)
         }
     }
 

--- a/Sources/PouchFramework/Models/Input.swift
+++ b/Sources/PouchFramework/Models/Input.swift
@@ -10,11 +10,13 @@ public enum Input: Codable, Equatable {
         public static let firebaseRemoteConfig = "firebase"
         public static let environmentVariable = "env"
         public static let onePassword = "1password"
+        public static let dotenv = "dotenv"
     }
 
     public enum CodingKeys: String, CodingKey {
         case type
         case configPath
+        case filePath
         case vault
         case account
         case section
@@ -24,12 +26,14 @@ public enum Input: Codable, Equatable {
     case onePassword(_ vault: String, _ account: String?, _ section: String, _ keyMapping: [String: String])
     case environmentVariable(_ keyMapping: [String: String])
     case firebaseRemoteConfig(String, _ keyMapping: [String: String])
+    case dotenv(_ filePath: String, _ keyMapping: [String: String])
 
     public var typeDescription: String {
         switch self {
         case .onePassword: Constants.onePassword
         case .environmentVariable: Constants.environmentVariable
         case .firebaseRemoteConfig: Constants.firebaseRemoteConfig
+        case .dotenv: Constants.dotenv
         }
     }
 
@@ -54,6 +58,9 @@ public enum Input: Codable, Equatable {
                     throw Error.sectionRequired
                 }
                 self = .onePassword(vault, account, section, keyMapping ?? [:])
+            case Constants.dotenv:
+                let filePath = try container.decodeIfPresent(String.self, forKey: .filePath) ?? ".env"
+                self = .dotenv(filePath, keyMapping ?? [:])
             default:
                 throw Error.invalidInputType
             }
@@ -85,6 +92,9 @@ public enum Input: Codable, Equatable {
             try container.encode(section, forKey: .section)
             try container.encode(keyMapping, forKey: .keyMapping)
         case let .environmentVariable(keyMapping):
+            try container.encode(keyMapping, forKey: .keyMapping)
+        case let .dotenv(filePath, keyMapping):
+            try container.encode(filePath, forKey: .filePath)
             try container.encode(keyMapping, forKey: .keyMapping)
         }
     }

--- a/Sources/PouchFramework/VariableFetchers/DotEnvFetcher.swift
+++ b/Sources/PouchFramework/VariableFetchers/DotEnvFetcher.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// Fetches variables from a `.env` file.
+public struct DotEnvFetcher {
+
+    public enum Error: Swift.Error {
+        case fileNotFound(path: String)
+        case unableToReadFile(path: String)
+        case unterminatedMultilineValue(key: String)
+    }
+
+    private let filePath: String
+
+    /// Creates a new `DotEnvFetcher`.
+    /// - Parameter filePath: Path to the `.env` file. Defaults to `.env` in the current directory.
+    public init(filePath: String = ".env") {
+        self.filePath = filePath
+    }
+
+    /// Fetches keys from the `.env` file.
+    /// - Parameters:
+    ///   - declarations: The key declarations to fetch.
+    ///   - keyMapping: Optional mapping from declaration names to `.env` variable names.
+    /// - Returns: An array of resolved keys.
+    public func fetch(declarations: [KeyDeclaration], keyMapping: [String: String]) async throws -> [Key] {
+        let environment = try parseEnvFile()
+        var resolvedKeys = [Key]()
+
+        for declaration in declarations {
+            let mappedKey = keyMapping[declaration.name] ?? declaration.name
+            guard let value = environment[mappedKey] else {
+                throw VariableFetchingError.variableNotFound(name: declaration.name, input: .dotenv(filePath, keyMapping))
+            }
+            resolvedKeys.append(declaration.with(value: value))
+        }
+
+        return resolvedKeys
+    }
+
+    /// Parses the `.env` file and returns a dictionary of key-value pairs.
+    private func parseEnvFile() throws -> [String: String] {
+        let url = URL(fileURLWithPath: filePath)
+
+        guard FileManager.default.fileExists(atPath: filePath) else {
+            throw Error.fileNotFound(path: filePath)
+        }
+
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+            throw Error.unableToReadFile(path: filePath)
+        }
+
+        var environment: [String: String] = [:]
+        let lines = contents.components(separatedBy: "\n")
+        var index = 0
+
+        while index < lines.count {
+            let line = lines[index]
+            let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+
+            // Skip empty lines and comments
+            if trimmedLine.isEmpty || trimmedLine.hasPrefix("#") {
+                index += 1
+                continue
+            }
+
+            // Find the first equals sign
+            guard let equalsIndex = trimmedLine.firstIndex(of: "=") else {
+                index += 1
+                continue
+            }
+
+            let key = String(trimmedLine[..<equalsIndex]).trimmingCharacters(in: .whitespaces)
+            var value = String(trimmedLine[trimmedLine.index(after: equalsIndex)...])
+
+            // Check for multi-line heredoc syntax (""" or ''')
+            if value.hasPrefix("\"\"\"") || value.hasPrefix("'''") {
+                let delimiter = String(value.prefix(3))
+                var multilineValue = String(value.dropFirst(3))
+                index += 1
+
+                // Collect lines until we find the closing delimiter
+                while index < lines.count {
+                    let nextLine = lines[index]
+                    if nextLine.contains(delimiter) {
+                        // Found closing delimiter
+                        if let delimiterIndex = nextLine.range(of: delimiter) {
+                            multilineValue += "\n" + String(nextLine[..<delimiterIndex.lowerBound])
+                        }
+                        break
+                    } else {
+                        multilineValue += "\n" + nextLine
+                        index += 1
+                    }
+                }
+
+                if index >= lines.count && !lines[index - 1].contains(delimiter) {
+                    throw Error.unterminatedMultilineValue(key: key)
+                }
+
+                value = multilineValue
+            } else {
+                value = value.trimmingCharacters(in: .whitespaces)
+
+                // Remove surrounding quotes if present (single line)
+                if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+                   (value.hasPrefix("'") && value.hasSuffix("'")) {
+                    value = String(value.dropFirst().dropLast())
+                }
+            }
+
+            if !key.isEmpty {
+                environment[key] = value
+            }
+
+            index += 1
+        }
+
+        // Perform variable interpolation
+        environment = interpolateVariables(in: environment)
+
+        return environment
+    }
+
+    /// Interpolates variable references like `${VAR}` with their values.
+    /// - Parameter environment: The parsed environment dictionary.
+    /// - Returns: A new dictionary with interpolated values.
+    private func interpolateVariables(in environment: [String: String]) -> [String: String] {
+        var result = environment
+        let pattern = "\\$\\{([^}]+)\\}"
+
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return environment
+        }
+
+        // Multiple passes to handle nested references
+        for _ in 0..<10 {
+            var changed = false
+
+            for (key, value) in result {
+                let range = NSRange(value.startIndex..., in: value)
+                var newValue = value
+
+                // Find all matches in reverse order to preserve indices
+                let matches = regex.matches(in: value, range: range).reversed()
+
+                for match in matches {
+                    guard let varNameRange = Range(match.range(at: 1), in: value) else {
+                        continue
+                    }
+
+                    let varName = String(value[varNameRange])
+
+                    // Look up the variable in our environment first, then system environment
+                    if let replacement = result[varName] ?? ProcessInfo.processInfo.environment[varName] {
+                        guard let fullMatchRange = Range(match.range, in: newValue) else {
+                            continue
+                        }
+                        newValue.replaceSubrange(fullMatchRange, with: replacement)
+                        changed = true
+                    }
+                }
+
+                result[key] = newValue
+            }
+
+            if !changed {
+                break
+            }
+        }
+
+        return result
+    }
+}

--- a/Tests/PouchTests/VariableFetchers/DotEnvFetcherTests.swift
+++ b/Tests/PouchTests/VariableFetchers/DotEnvFetcherTests.swift
@@ -1,0 +1,346 @@
+import XCTest
+@testable import PouchFramework
+
+final class DotEnvFetcherTests: XCTestCase {
+
+    // MARK: - Basic Parsing Tests
+
+    func test_parsesSimpleKeyValuePairs() async throws {
+        let envContent = """
+        API_KEY=secret123
+        DATABASE_URL=postgres://localhost
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "API_KEY"), KeyDeclaration(name: "DATABASE_URL")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertEqual(keys[0].value, "secret123")
+        XCTAssertEqual(keys[1].value, "postgres://localhost")
+    }
+
+    func test_handlesQuotedValues() async throws {
+        let envContent = """
+        DOUBLE_QUOTED="hello world"
+        SINGLE_QUOTED='hello world'
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "DOUBLE_QUOTED"), KeyDeclaration(name: "SINGLE_QUOTED")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        XCTAssertEqual(keys[0].value, "hello world")
+        XCTAssertEqual(keys[1].value, "hello world")
+    }
+
+    func test_skipsCommentsAndEmptyLines() async throws {
+        let envContent = """
+        # This is a comment
+        API_KEY=secret
+
+        # Another comment
+        DATABASE=test
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "API_KEY"), KeyDeclaration(name: "DATABASE")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertEqual(keys[0].value, "secret")
+        XCTAssertEqual(keys[1].value, "test")
+    }
+
+    func test_handlesValuesWithEqualsSign() async throws {
+        let envContent = """
+        CONNECTION_STRING=host=localhost;port=5432
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "CONNECTION_STRING")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        XCTAssertEqual(keys[0].value, "host=localhost;port=5432")
+    }
+
+    func test_handlesKeyMapping() async throws {
+        let envContent = """
+        MY_CUSTOM_KEY=mapped_value
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "API_KEY")]
+        let keyMapping = ["API_KEY": "MY_CUSTOM_KEY"]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: keyMapping)
+
+        XCTAssertEqual(keys[0].value, "mapped_value")
+    }
+
+    // MARK: - Variable Interpolation Tests
+
+    func test_interpolatesVariableReferences() async throws {
+        let envContent = """
+        USERNAME=admin
+        EMAIL=${USERNAME}@example.com
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "EMAIL")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        XCTAssertEqual(keys[0].value, "admin@example.com")
+    }
+
+    func test_interpolatesMultipleVariablesInSameValue() async throws {
+        let envContent = """
+        HOST=localhost
+        PORT=5432
+        CONNECTION=${HOST}:${PORT}
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "CONNECTION")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        XCTAssertEqual(keys[0].value, "localhost:5432")
+    }
+
+    func test_handlesNestedVariableReferences() async throws {
+        let envContent = """
+        BASE=example
+        DOMAIN=${BASE}.com
+        URL=https://${DOMAIN}/api
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "URL")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        XCTAssertEqual(keys[0].value, "https://example.com/api")
+    }
+
+    func test_preservesUnresolvedVariables() async throws {
+        let envContent = """
+        MESSAGE=Hello ${UNDEFINED_VAR}!
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "MESSAGE")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        // Unresolved variables should be preserved as-is
+        XCTAssertEqual(keys[0].value, "Hello ${UNDEFINED_VAR}!")
+    }
+
+    // MARK: - Multi-line Value Tests
+
+    func test_parsesMultilineValuesWithDoubleQuotes() async throws {
+        let envContent = """
+        PRIVATE_KEY=\"\"\"
+        -----BEGIN KEY-----
+        abc123
+        -----END KEY-----
+        \"\"\"
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "PRIVATE_KEY")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        let expectedValue = """
+
+        -----BEGIN KEY-----
+        abc123
+        -----END KEY-----
+
+        """
+        XCTAssertEqual(keys[0].value, expectedValue)
+    }
+
+    func test_parsesMultilineValuesWithSingleQuotes() async throws {
+        let envContent = """
+        CERTIFICATE='''
+        line1
+        line2
+        line3
+        '''
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "CERTIFICATE")]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        let expectedValue = """
+
+        line1
+        line2
+        line3
+
+        """
+        XCTAssertEqual(keys[0].value, expectedValue)
+    }
+
+    // MARK: - Integration Test
+
+    func test_comprehensiveEnvFileParsing() async throws {
+        let envContent = """
+        # Database configuration
+        DB_HOST=localhost
+        DB_PORT=5432
+        DB_USER=admin
+        DB_PASSWORD="super_secret_123"
+
+        # Derived connection string using interpolation
+        DB_CONNECTION=${DB_HOST}:${DB_PORT}
+        DB_URL=postgres://${DB_USER}:${DB_PASSWORD}@${DB_CONNECTION}/mydb
+
+        # App settings with quotes
+        APP_NAME='My Test App'
+        APP_DESCRIPTION="A great app for testing"
+
+        # Multi-line certificate
+        SSL_CERT=\"\"\"
+        -----BEGIN CERTIFICATE-----
+        MIICpDCCAYwCCQDU+pQ4P2dG3DANBgkqhkiG9w0BAQsFADAUMRIw
+        -----END CERTIFICATE-----
+        \"\"\"
+
+        # Nested interpolation
+        BASE_DOMAIN=example
+        FULL_DOMAIN=${BASE_DOMAIN}.com
+        API_ENDPOINT=https://${FULL_DOMAIN}/api/v1
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [
+            KeyDeclaration(name: "DB_HOST"),
+            KeyDeclaration(name: "DB_PORT"),
+            KeyDeclaration(name: "DB_USER"),
+            KeyDeclaration(name: "DB_PASSWORD"),
+            KeyDeclaration(name: "DB_CONNECTION"),
+            KeyDeclaration(name: "DB_URL"),
+            KeyDeclaration(name: "APP_NAME"),
+            KeyDeclaration(name: "APP_DESCRIPTION"),
+            KeyDeclaration(name: "SSL_CERT"),
+            KeyDeclaration(name: "API_ENDPOINT"),
+        ]
+        let keys = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+
+        // Basic values
+        XCTAssertEqual(keys[0].value, "localhost")
+        XCTAssertEqual(keys[1].value, "5432")
+        XCTAssertEqual(keys[2].value, "admin")
+
+        // Quoted value
+        XCTAssertEqual(keys[3].value, "super_secret_123")
+
+        // Simple interpolation
+        XCTAssertEqual(keys[4].value, "localhost:5432")
+
+        // Complex interpolation with multiple variables
+        XCTAssertEqual(keys[5].value, "postgres://admin:super_secret_123@localhost:5432/mydb")
+
+        // Single-quoted value
+        XCTAssertEqual(keys[6].value, "My Test App")
+
+        // Double-quoted value
+        XCTAssertEqual(keys[7].value, "A great app for testing")
+
+        // Multi-line value
+        let expectedCert = """
+
+        -----BEGIN CERTIFICATE-----
+        MIICpDCCAYwCCQDU+pQ4P2dG3DANBgkqhkiG9w0BAQsFADAUMRIw
+        -----END CERTIFICATE-----
+
+        """
+        XCTAssertEqual(keys[8].value, expectedCert)
+
+        // Nested interpolation (3 levels deep)
+        XCTAssertEqual(keys[9].value, "https://example.com/api/v1")
+    }
+
+    // MARK: - Error Tests
+
+    func test_throwsErrorForMissingFile() async {
+        let fetcher = DotEnvFetcher(filePath: "/nonexistent/.env")
+        let declarations = [KeyDeclaration(name: "API_KEY")]
+
+        do {
+            _ = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(error is DotEnvFetcher.Error)
+        }
+    }
+
+    func test_throwsErrorForMissingKey() async throws {
+        let envContent = """
+        OTHER_KEY=value
+        """
+        let envFile = try envContent.saveToTemporaryDirectory(filename: ".env")
+        defer { try? FileManager.default.removeItem(at: envFile) }
+
+        let fetcher = DotEnvFetcher(filePath: envFile.path)
+        let declarations = [KeyDeclaration(name: "MISSING_KEY")]
+
+        do {
+            _ = try await fetcher.fetch(declarations: declarations, keyMapping: [:])
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(error is VariableFetchingError)
+        }
+    }
+
+    static var allTests = [
+        ("test_parsesSimpleKeyValuePairs", test_parsesSimpleKeyValuePairs),
+        ("test_handlesQuotedValues", test_handlesQuotedValues),
+        ("test_skipsCommentsAndEmptyLines", test_skipsCommentsAndEmptyLines),
+        ("test_handlesValuesWithEqualsSign", test_handlesValuesWithEqualsSign),
+        ("test_handlesKeyMapping", test_handlesKeyMapping),
+        ("test_interpolatesVariableReferences", test_interpolatesVariableReferences),
+        ("test_interpolatesMultipleVariablesInSameValue", test_interpolatesMultipleVariablesInSameValue),
+        ("test_handlesNestedVariableReferences", test_handlesNestedVariableReferences),
+        ("test_preservesUnresolvedVariables", test_preservesUnresolvedVariables),
+        ("test_parsesMultilineValuesWithDoubleQuotes", test_parsesMultilineValuesWithDoubleQuotes),
+        ("test_parsesMultilineValuesWithSingleQuotes", test_parsesMultilineValuesWithSingleQuotes),
+        ("test_comprehensiveEnvFileParsing", test_comprehensiveEnvFileParsing),
+        ("test_throwsErrorForMissingFile", test_throwsErrorForMissingFile),
+        ("test_throwsErrorForMissingKey", test_throwsErrorForMissingKey),
+    ]
+}
+
+// MARK: - Test Helpers
+
+private extension String {
+    func saveToTemporaryDirectory(filename: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename + "-" + UUID().uuidString)
+        try write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a new `dotenv` input type that reads secrets directly from `.env` files, eliminating the need to manually `source .env` before running `pouch retrieve`.

### Features
- New `dotenv` input type with optional `filePath` parameter (defaults to `.env`)
- Variable interpolation support (`${VAR}` syntax)
- Multi-line values using heredoc syntax (`"""` or `'''`)
- Comprehensive unit tests including an integration test

### Usage

```yaml
keys:
  - API_KEY
  - DATABASE_URL

input:
  type: dotenv
  filePath: ./.env  # optional, defaults to .env

outputs:
  - filePath: ./Secrets.swift
    typeName: Secrets
```

### Example `.env` file

```env
# Comments are supported
API_KEY=secret123

# Variable interpolation
DB_HOST=localhost
DB_PORT=5432
DB_CONNECTION=${DB_HOST}:${DB_PORT}

# Multi-line values
PRIVATE_KEY="""
-----BEGIN RSA PRIVATE KEY-----
MIIEpAIBAAKCAQEAw...
-----END RSA PRIVATE KEY-----
"""
```

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)